### PR TITLE
Move "Rendered At" into templates

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,12 +20,12 @@ jobs:
       - name: Setup ruby
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: '2.5' 
+          ruby-version: '2.5'
       - name: Generate reports
         run: |
           gem install bundler
           ### generate pr graphs
-          bundle install 
+          bundle install
           bundle exec ruby pr_work_done.rb -t $token
           bundle exec ruby daily_open_prs.rb -t $token
           bundle exec ruby graph.rb --pr_work_done --created_prs_per_day --open_prs_per_day
@@ -34,7 +34,7 @@ jobs:
           ### generate prs for tools report
           bundle exec ruby tools.rb -t $token
           ### generate release planning
-          bundle exec ruby release_planning.rb -t $token 
+          bundle exec ruby release_planning.rb -t $token
           ### generate github actions report
           bundle exec ruby github_actions_report.rb -t $token
       - name: List files
@@ -45,11 +45,6 @@ jobs:
           cp -r *.png docs/
           cp -r *.csv docs/
           ls -la docs/
-      - name: Add timestamp
-        run: |
-          data=$("date")
-          echo "Adding timestamp $data"
-          sed -i -e "s|<p>.*<\/p>|<p>$data</p>|g" index.html
       - name: Commit files
         run: |
           git config --local user.email "action@github.com"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,12 +18,12 @@ jobs:
       - name: Setup ruby
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: '2.5' 
+          ruby-version: '2.5'
       - name: Generate reports
         run: |
           gem install bundler
           ### generate pr graphs
-          bundle install 
+          bundle install
           bundle exec ruby pr_work_done.rb -t $token
           bundle exec ruby daily_open_prs.rb -t $token
           bundle exec ruby graph.rb --pr_work_done --created_prs_per_day --open_prs_per_day
@@ -32,7 +32,7 @@ jobs:
           ### generate prs for tools report
           bundle exec ruby tools.rb -t $token
           ### generate release planning
-          bundle exec ruby release_planning.rb -t $token 
+          bundle exec ruby release_planning.rb -t $token
           ### generate github actions report
           bundle exec ruby github_actions_report.rb -t $token
       - name: List files
@@ -43,11 +43,6 @@ jobs:
           cp -r *.png docs/
           cp -r *.csv docs/
           ls -la docs/
-      - name: Add timestamp
-        run: |
-          data=$("date")
-          echo "Adding timestamp $data"
-          sed -i -e "s|<p>.*<\/p>|<p>$data</p>|g" index.html
       - name: Commit files
         run: |
           git config --local user.email "action@github.com"

--- a/github_actions_report.html.erb
+++ b/github_actions_report.html.erb
@@ -63,6 +63,6 @@
 	  </tr>
   <% end %>
 </table>
+<div class="footer">Rendered at <%= require 'date'; DateTime.now.strftime("%+") %></div>
 </body>
 </html>
-

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
- 
+
     ga('create', 'UA-157301458-1', 'auto');
   ga('send', 'pageview', { 'page': location.pathname + location.search + location.hash});
   ga('set', 'anonymizeIp', true);
@@ -35,8 +35,5 @@
   </ul>
 
 <iframe height="100%" width="100%" src="graph.html" name="iframe_a"></iframe>
-<div class="footer">
-<p>Wed Jun 10 02:19:14 UTC 2020</p>
-</div>
 </body>
 </html>

--- a/pr_review_list.html.erb
+++ b/pr_review_list.html.erb
@@ -164,5 +164,6 @@
   </tr>
 <% end %> 
 </table>
+<div class="footer">Rendered at <%= require 'date'; DateTime.now.strftime("%+") %></div>
 </body>
 </html>

--- a/release_planning.html.erb
+++ b/release_planning.html.erb
@@ -57,5 +57,6 @@
   <td align=\"center\"><%= puppet_module['downloads']%></td>
   </tr>
 <% end %>
+<div class="footer">Rendered at <%= require 'date'; DateTime.now.strftime("%+") %></div>
 </body>
 </html>

--- a/stats.html.erb
+++ b/stats.html.erb
@@ -17,7 +17,6 @@
   <% end %>
 </table>
 <% end %>
+<div class="footer">Rendered at <%= require 'date'; DateTime.now.strftime("%+") %></div>
 </body>
 </html>
-
-

--- a/tools.html.erb
+++ b/tools.html.erb
@@ -115,5 +115,6 @@
   </tr>
 <% end %> 
 </table>
+<div class="footer">Rendered at <%= require 'date'; DateTime.now.strftime("%+") %></div>
 </body>
 </html>


### PR DESCRIPTION
Instead of fudging with the one static page on the site, render
the rendered-at-date into the actual reports. This also makes sure
that if one report fails and is not updated that there is a chance
of noticing.