### PR TITLE
Adds ability to manage labels on single repository

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 source 'https://rubygems.org'
 gem 'octokit'
 gem 'rest-client'
+gem 'rugged'
 # gruff appears to have gone dormant. This allows it to install with current
 # rmagick, which fixes an imagemagick@6 pkg-config bug.
 # https://github.com/topfunky/gruff/pull/186

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Labels
 -------
 
 Puts a set of labels into each repository. Creates them in a non destructive way.
+By default, it will run against supported Puppet modules, but you can run it on
+a single module repository in a few ways:
+
+* `--repo <namespace/repo>`
+* `--repo` (uses the first found of the `upstream` or `origin` remotes of CWD)
+* `--remote <name>` (uses the url of the remote name passed in the CWD)
 
 Npc
 ----

--- a/labels.rb
+++ b/labels.rb
@@ -11,7 +11,9 @@ def primary_remote
 end
 
 def get_remote(name)
-  parts = `git remote get-url #{name} 2>/dev/null`.match(/(\w+\/[\w-]+)(?:\.git)?$/)
+  require 'rugged'
+  remote = Rugged::Repository.new('.').remotes[name] rescue nil
+  parts  = remote.url.match(/(\w+\/[\w-]+)(?:\.git)?$/) if remote
   parts[1] if parts
 end
 

--- a/labels.rb
+++ b/labels.rb
@@ -4,17 +4,41 @@
 require_relative 'octokit_utils'
 require_relative 'options'
 
+def primary_remote
+  ['upstream', 'origin'].map do |name|
+    get_remote(name)
+  end.compact.first
+end
+
+def get_remote(name)
+  parts = `git remote get-url #{name} 2>/dev/null`.match(/(\w+\/[\w-]+)(?:\.git)?$/)
+  parts[1] if parts
+end
+
 options = parse_options do |opts, result|
   opts.on('-f', '--fix-labels', 'Add the missing labels to repo') { result[:fix_labels] = true }
   opts.on('-d', '--delete-labels', 'Delete unwanted labels from repo') { result[:delete_labels] = true }
+
+  opts.on('--repo [REPO]', 'Pass a repository name, defaults to the current upstream.') do |v|
+    result[:remote] = v || primary_remote
+    raise 'Could not guess primary remote. Try using --remote instead.' unless result[:remote]
+  end
+
+  opts.on('--remote REMOTE', 'Name of a remote to work on.') do |v|
+    result[:remote] = get_remote(v)
+    raise "No url set for remote #{v}" unless result[:remote]
+  end
 end
 
-parsed = load_url(options)
+if options[:remote]
+  parsed = { options[:remote] => { 'github' => options[:remote] } }
+else
+  parsed = load_url(options)
+end
 
 util = OctokitUtils.new(options[:oauth])
 
 wanted_labels = [{ name: 'needs-squash', color: 'bfe5bf' }, { name: 'needs-rebase', color: '3880ff' }, { name: 'needs-tests', color: 'ff8091' }, { name: 'needs-docs', color: '149380' }, { name: 'bugfix', color: '00d87b' }, { name: 'feature', color: '222222' }, { name: 'tests-fail', color: 'e11d21' }, { name: 'backwards-incompatible', color: 'd63700' }, { name: 'maintenance', color: 'ffd86e' }]
-parsed = util.load_module_list(options[:file])
 
 label_names = []
 wanted_labels.each do |wanted_label|


### PR DESCRIPTION
This allows you to add the proper labels to any given repository. For
example, one might use it to add labels to a newly created module
without adding to the IAC team's matrix.

Note: this is a rework of https://github.com/underscorgan/community_management/pull/73