### PR TITLE
(maint) gruff is no longer used

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,6 @@ source 'https://rubygems.org'
 gem 'octokit'
 gem 'rest-client'
 gem 'rugged'
-# gruff appears to have gone dormant. This allows it to install with current
-# rmagick, which fixes an imagemagick@6 pkg-config bug.
-# https://github.com/topfunky/gruff/pull/186
-gem 'gruff', github: 'Watson1978/gruff', branch: 'master'
 
 group 'development' do
   gem 'pry'


### PR DESCRIPTION
Removing it from the Gemfile removes the runtime dependency on
Imagemagick, which is kinda huge.

Thanks for catching this, @kreeuwijk 