### PR TITLE
fix broken label script

### DIFF
--- a/labels.rb
+++ b/labels.rb
@@ -53,8 +53,6 @@ wanted_labels = [
   { name: 'tests-fail', color: 'e11d21' },
 ]
 
-parsed = util.load_module_list(options[:file])
-
 label_names = []
 wanted_labels.each do |wanted_label|
   label_names.push(wanted_label[:name])


### PR DESCRIPTION
This removes a call to a method that was removed in https://github.com/puppetlabs/community_management/commit/c648ec39301c58d0f04ebb9499abeacf7595a3b6#diff-91a659de0d57ab355f1b8ee4656310e5