### PR TITLE
(maint) remove total from donut

### DIFF
--- a/daily_open_prs.rb
+++ b/daily_open_prs.rb
@@ -79,7 +79,7 @@ end
 CSV.open('daily_open_prs.csv', 'wb') do |csv|
   csv << %w[ community puppet total]
   days.each do |day|
-    csv << [day['community'], day['puppet'], day['total']]
+    csv << [day['community'], day['puppet']]
   end
 end
 CSV.open('created_per_day.csv', 'wb') do |csv|


### PR DESCRIPTION
Having the both the parts and sum of the total made the currently open
PRs donut chart confusing. This just removes the total so it's more
readable. If this CSV is consumed by other tools, we can do this in
another way by hiding the column in the C3 chart definition.
