### PR TITLE
(maint) adds a script to update topics on repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ a single module repository in a few ways:
 * `--repo` (uses the first found of the `upstream` or `origin` remotes of CWD)
 * `--remote <name>` (uses the url of the remote name passed in the CWD)
 
+Topics
+-------
+
+Ensures a set of topics on repos. Works in a non destructive way unless you instruct
+it to delete topics. By default, if will run against IAC supported modules, but
+you can use the same individual repository options as you can with Labels.
+
 Npc
 ----
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Topics
 -------
 
 Ensures a set of topics on repos. Works in a non destructive way unless you instruct
-it to delete topics. By default, if will run against IAC supported modules, but
+it to delete topics. By default, it will run against IAC supported modules, but
 you can use the same individual repository options as you can with Labels.
 
 Npc

--- a/options.rb
+++ b/options.rb
@@ -7,11 +7,23 @@ def parse_options
   result[:oauth] = ENV['GITHUB_TOKEN'] if ENV['GITHUB_TOKEN']
   result[:oauth] = ENV['GITHUB_COMMUNITY_TOKEN'] if ENV['GITHUB_COMMUNITY_TOKEN']
   result[:url] = 'https://puppetlabs.github.io/iac/modules.json'
+  result[:modules] = 'https://puppetlabs.github.io/iac/modules.json'
+  result[:tools]   = 'https://puppetlabs.github.io/iac/tools.json'
 
   parser = OptionParser.new do |opts|
     opts.banner = "Usage: #{$PROGRAM_NAME} [options]"
     opts.on('-u MANDATORY', '--url=MANDATORY', String, 'Link to json file for modules') { |v| result[:url] = v }
     opts.on('-t', '--oauth-token TOKEN', 'OAuth token. Required.') { |v| result[:oauth] = v }
+    opts.on('-g', '--group GROUP', 'Repository group to operate on. One of [modules|tools]') do |v|
+      case v.downcase
+      when 'modules'
+        result[:url] = result[:modules]
+      when 'tools'
+        result[:url] = result[:tools]
+      else
+        raise "Unsupported repository group. Please use one of [modules|tools]."
+      end
+    end
     yield opts, result if block_given?
   end
 

--- a/topics.rb
+++ b/topics.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative 'octokit_utils'
+require_relative 'options'
+
+def primary_remote
+  ['upstream', 'origin'].map do |name|
+    get_remote(name)
+  end.compact.first
+end
+
+def get_remote(name)
+  require 'rugged'
+  remote = Rugged::Repository.new('.').remotes[name] rescue nil
+  parts  = remote.url.match(/(\w+\/[\w-]+)(?:\.git)?$/) if remote
+  parts[1] if parts
+end
+
+options = parse_options do |opts, result|
+  opts.on('-f', '--fix-topics', 'Add the missing topics to repo') { result[:fix_topics] = true }
+  opts.on('-d', '--delete-topics', 'Delete unwanted topics from repo') { result[:delete_topics] = true }
+
+  opts.on('--repo [REPO]', 'Pass a repository name, defaults to the current upstream.') do |v|
+    result[:remote] = v || primary_remote
+    raise 'Could not guess primary remote. Try using --remote instead.' unless result[:remote]
+  end
+
+  opts.on('--remote REMOTE', 'Name of a remote to work on.') do |v|
+    result[:remote] = get_remote(v)
+    raise "No url set for remote #{v}" unless result[:remote]
+  end
+end
+
+if options[:remote]
+  parsed = { options[:remote] => { 'github' => options[:remote] } }
+else
+  parsed = load_url(options)
+end
+
+util = OctokitUtils.new(options[:oauth])
+
+wanted_topics = [ 'hacktoberfest' ]
+
+puts "Checking for the following topics: #{wanted_topics}"
+
+parsed.each do |_k, v|
+  repo_name = (v['github']).to_s
+
+  topics  = util.client.topics(repo_name)[:names]
+  extra   = topics - wanted_topics
+  missing = wanted_topics - topics
+  final   = topics
+
+  if options[:delete_topics]
+    final -= extra
+  end
+  if options[:fix_topics]
+    final += missing
+  end
+
+  puts "Delete: #{repo_name}, #{extra}"
+  puts "Create: #{repo_name}, #{missing}"
+  puts "Topics: #{repo_name}, #{final}"
+
+  next unless options.include?(:delete_topics) or options.include?(:fix_topics)
+  util.client.replace_all_topics(repo_name, final)
+end


### PR DESCRIPTION
This uses the same repository inspection as labels.rb, so it accepts the
same options. It also adds another global option of `-g`/`--group` which
is a quick & simple switch between `modules.json` and `tools.json`.