### PR TITLE
Added back the ability to manage labels on multiple repos

### DIFF
--- a/octokit_utils.rb
+++ b/octokit_utils.rb
@@ -43,6 +43,27 @@ class OctokitUtils
   # orginazation than it does for getting the repositories of a user. This
   # method checks the "type" of a given namespace and uses the value to
   # determine the method to call.
+  def ns_repos(namespace)
+    ns_type = (client.user "#{namespace}").type
+    if ns_type.eql? 'Organization'
+      client.organization_repositories(namespace)
+    else
+      client.repositories(namespace)
+    end
+  end
+
+  def list_repos(namespace, options)
+    if not options[:repo_regex]
+      regex = '.*'
+    else
+      regex = options[:repo_regex]
+    end
+
+    repos ||= ns_repos(namespace).collect {|ns_repo| ns_repo[:name] if ns_repo[:name] =~ /#{regex}/}
+    # The collection leaves nil entries in for non-matches
+    repos = repos.select {|repo| repo }
+    return repos.sort.uniq
+  end
 
   def pulls(repo, options)
     @pr_cache[[repo, options]] ||= client.pulls(repo, options)


### PR DESCRIPTION
Ported functionality back from the upstream repo that was later removed: https://github.com/underscorgan/community_management/tree/80822a5664e07643b141f5813ef7a4d1a20a12be