### PR TITLE
Solve limitation problem for agent_os

### DIFF
--- a/github_actions_report.rb
+++ b/github_actions_report.rb
@@ -38,7 +38,7 @@ parsed.each do |_k, v|
     runs = JSON.parse(runs_json)
     runs['workflow_runs'][0..4].each do |run|
       @general_conclusion = false
-      jobs_json = JSON.parse(RestClient.get(run['jobs_url'], headers))        
+      jobs_json = JSON.parse(RestClient.get("#{run['jobs_url']}?per_page=100", headers))        
       os_agent = jobs_json['jobs'].select { |job| job['name'].include?('puppet') }.map { |job| parse_job(job, v['github']) }
       job_failures = os_agent.select { |x| x[:result] == 'failure' }.length
       job_successes = os_agent.select { |x| x[:result] == 'success' }.length


### PR DESCRIPTION
Currently for java_ks module/firewall we don't see all the os es and agents from the run ( check: https://github.com/puppetlabs/puppetlabs-java_ks/actions/runs/772476121 and CM action page) because per_page parameter is set on default (30).
result: 
`{:os=>"Windows-2012 R2", :agent=>"puppet6-nightly", :result=>"failure", :url=>"https://github.com/puppetlabs/puppetlabs-java_ks/runs/2395921911?check_suite_focus=true"}
{:os=>"Windows-2012 R2", :agent=>"puppet7-nightly", :result=>"failure", :url=>"https://github.com/puppetlabs/puppetlabs-java_ks/runs/2395921931?check_suite_focus=true"}
{:os=>"Windows-2016", :agent=>"puppet6-nightly", :result=>"failure", :url=>"https://github.com/puppetlabs/puppetlabs-java_ks/runs/2395921949?check_suite_focus=true"}
{:os=>"Windows-2016", :agent=>"puppet7-nightly", :result=>"failure", :url=>"https://github.com/puppetlabs/puppetlabs-java_ks/runs/2395921963?check_suite_focus=true"}
{:os=>"Windows-2019", :agent=>"puppet6-nightly", :result=>"failure", :url=>"https://github.com/puppetlabs/puppetlabs-java_ks/runs/2395921989?check_suite_focus=true"}
{:os=>"Windows-2019", :agent=>"puppet7-nightly", :result=>"failure", :url=>"https://github.com/puppetlabs/puppetlabs-java_ks/runs/2395922017?check_suite_focus=true"}`