### PR TITLE
Ignore archived repositories

### DIFF
--- a/labels.rb
+++ b/labels.rb
@@ -78,6 +78,7 @@ parsed.each do |_k, v|
   else
     repo_name = (v['github']).to_s
   end
+  next if util.repo_is_archived?(repo_name)
   missing_labels = util.fetch_repo_missing_labels(repo_name, wanted_labels)
   incorrect_labels = util.fetch_repo_incorrect_labels(repo_name, wanted_labels)
   extra_labels = util.fetch_repo_extra_labels(repo_name, wanted_labels)

--- a/octokit_utils.rb
+++ b/octokit_utils.rb
@@ -65,6 +65,10 @@ class OctokitUtils
     return repos.sort.uniq
   end
 
+  def repo_is_archived?(repo)
+    @client.repository(repo).archived
+  end
+
   def pulls(repo, options)
     @pr_cache[[repo, options]] ||= client.pulls(repo, options)
   end


### PR DESCRIPTION
Updating an archived repository raise an exception.  Add an utility
method to check archival status and use it in the label script to
mass-update repositories labels.