### PR TITLE
(MAINT) Add community label

### DIFF
--- a/labels.rb
+++ b/labels.rb
@@ -55,6 +55,7 @@ end
 wanted_labels = [
   { name: 'backwards-incompatible', color: 'd63700' },
   { name: 'bugfix', color: '00d87b' },
+  { name: 'community', color: '5319e7' },
   { name: 'dependencies', color: '0366d6' },
   { name: 'feature', color: '222222' },
   { name: 'maintenance', color: 'ffd86e' },


### PR DESCRIPTION
## Context

We've introduced a new label to identify community contributions. The new label will help us organise and prioritise our community work in the background.

## What has changed?

This PR adds the a new hash to the `wanted_labels` list so that we can ensure consistency between our repos.